### PR TITLE
Fix unassigned employee display in task pool

### DIFF
--- a/src/pages/admin/TaskPool.tsx
+++ b/src/pages/admin/TaskPool.tsx
@@ -238,7 +238,16 @@ export default function TaskPool() {
                                 {task.priority}
                               </span>
                               <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-gray-100 text-gray-800">
-                                Unassigned
+                              {(() => {
+                                const selected = Array.from(selectedAssigneesByTask[task.id] || new Set<string>());
+                                if (selected.length > 0) {
+                                  const names = selected
+                                    .map((id) => employees.find((e) => e.id === id)?.full_name)
+                                    .filter(Boolean) as string[];
+                                  return names.join(', ');
+                                }
+                                return 'Unassigned';
+                              })()}
                               </span>
                             </div>
                           </div>


### PR DESCRIPTION
Display selected employee names in the Task Pool UI instead of "Unassigned" to accurately reflect assignments.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c02432e-bf2c-4ce0-8190-426c76d7b309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c02432e-bf2c-4ce0-8190-426c76d7b309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

